### PR TITLE
Add Easy_URLS with repo and Pages links

### DIFF
--- a/Easy_URLS
+++ b/Easy_URLS
@@ -1,0 +1,10 @@
+# CALHN Data Collection
+
+[Visit the GitHub Pages site](https://github.com/CALHN-DataCollection)
+
+## Repository Information
+
+This repository contains data collection tools and resources for CALHN.
+
+For the live GitHub Pages version, visit:
+https://[username].github.io/CALHN-DataCollection/


### PR DESCRIPTION
Add a new Easy_URLS file listing the CALHN Data Collection repository and GitHub Pages URLs. Provides quick reference links and brief repository information for contributors and site visitors.