### PR TITLE
Migrate OOS graphs from hardcoded data to Google Sheets

### DIFF
--- a/GOOGLE_SHEETS_SETUP.md
+++ b/GOOGLE_SHEETS_SETUP.md
@@ -1,0 +1,94 @@
+# Google Sheets Setup Guide
+
+How to create and connect the three data sheets to the OOS graphs.
+
+---
+
+## 1. Create the sheets
+
+Create three separate Google Sheets — one per service:
+
+| Sheet | Used by |
+|---|---|
+| Music Therapy OOS | `music_therapy_oos_graph.html` |
+| Art Therapy OOS | `art_therapy_oos_graph.html` |
+| Spiritual Care OOS | `spiritual_care_oos_graph.html` |
+
+---
+
+## 2. Set up the column structure
+
+Each sheet must use **exactly these column headers in row 1**:
+
+| A | B | C | D | E | F |
+|---|---|---|---|---|---|
+| Year | Month | New | Review | Total | Notes |
+
+Rules:
+- **Year** — four-digit year, e.g. `2025`
+- **Month** — three-letter abbreviation: `Jan`, `Feb`, `Mar`, `Apr`, `May`, `Jun`, `Jul`, `Aug`, `Sep`, `Oct`, `Nov`, `Dec`
+- **New** — number of new sessions. Leave blank if unknown.
+- **Review** — number of review sessions. Leave blank if unknown.
+- **Total** — total sessions for the month. Always fill this in.
+- **Notes** — free text, ignored by the graph.
+
+Example rows:
+
+```
+Year  Month  New  Review  Total  Notes
+2024  Jul    36            36
+2025  Jan    7             7
+2025  Jul    3    21       24
+```
+
+---
+
+## 3. Publish the sheet as CSV
+
+Each sheet needs to be published so the graph can read it.
+
+1. Open the sheet in Google Sheets
+2. Go to **File → Share → Publish to web**
+3. In the first dropdown, select the sheet tab (e.g. "Sheet1")
+4. In the second dropdown, select **Comma-separated values (.csv)**
+5. Click **Publish** and confirm
+6. Copy the URL that appears — it will look like:
+   ```
+   https://docs.google.com/spreadsheets/d/SPREADSHEET_ID/pub?gid=SHEET_GID&single=true&output=csv
+   ```
+
+---
+
+## 4. Paste the URL into the graph file
+
+Open the relevant HTML file and find this line near the top of the `<script>` section:
+
+```javascript
+const SHEET_CSV_URL = ""; // paste published CSV URL here
+```
+
+Paste the CSV URL between the quotes:
+
+```javascript
+const SHEET_CSV_URL = "https://docs.google.com/spreadsheets/d/YOUR_ID/pub?gid=0&single=true&output=csv";
+```
+
+Repeat for each of the three HTML files with their respective sheet URLs.
+
+---
+
+## 5. Test it
+
+Open the HTML file in a browser. The graph should load data from the sheet automatically. If it shows an error, check:
+
+- The sheet is published (step 3)
+- The URL is pasted correctly with no extra spaces
+- The column headers match exactly (case-sensitive): `Year`, `Month`, `New`, `Review`, `Total`
+
+Use the **Refresh** button on the graph to reload data without reopening the page.
+
+---
+
+## Updating data going forward
+
+See `NANCY_GUIDE.md` for the day-to-day update process — it's just adding a row to the sheet.

--- a/NANCY_GUIDE.md
+++ b/NANCY_GUIDE.md
@@ -1,0 +1,15 @@
+# How to Update the OOS Data
+
+## What you need
+
+Edit access to the three Google Sheets (Jarran will share these with you).
+
+## Adding a new month's data
+
+1. Open the relevant sheet (MT / Art Therapy / Spiritual Care)
+2. Add a new row at the bottom
+3. Fill in: Year, Month, New (if known), Review (if known), Total
+4. Leave New and Review blank if you only have a total figure
+5. Save — the graph updates automatically next time someone opens it
+
+## That's it. The graphs read directly from the sheet. No coding. No other steps.

--- a/art_therapy_oos_graph.html
+++ b/art_therapy_oos_graph.html
@@ -236,6 +236,25 @@
             padding-top: 12px;
             border-top: 1px solid #eee;
         }
+        .data-status {
+            text-align: center;
+            padding: 60px 20px;
+            color: #7f8c8d;
+            font-size: 14px;
+        }
+        .data-status.error { color: #e74c3c; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .spinner {
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            border: 2px solid rgba(91,160,138,0.2);
+            border-top-color: #5BA08A;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            vertical-align: middle;
+            margin-right: 8px;
+        }
     </style>
 </head>
 <body>
@@ -253,9 +272,11 @@
             <div style="text-align: center; margin-top: 15px;">
                 <button class="export-btn" onclick="exportToPNG()">&#128202; Export as PNG</button>
                 <button class="filter-btn" onclick="openDateRangeModal()">&#128197; Date Range</button>
+                <button class="filter-btn" onclick="fetchAndRender()">&#8635; Refresh</button>
             </div>
         </div>
 
+        <div id="dataStatus" class="data-status" style="display:none;"></div>
         <div class="chart-container">
             <canvas id="oosChart"></canvas>
         </div>
@@ -375,27 +396,18 @@
     </div>
 
     <script>
+        const SHEET_CSV_URL = ""; // paste published CSV URL here
+
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const MONTH_IDX = {Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};
 
-        // 2024 – Jul–Nov only; total OoS only (no New/Review breakdown)
-        const data2024Total  = [null, null, null, null, null, null, 36, 5, 10, 14, 7, null];
-
-        // 2025 – Jan–Jun: total only (no real breakdown); Jul–Dec: actual New/Review
-        const data2025New    = [null, null, null, null, null, null, 3, 3, 14, 11, 2, 13];
-        const data2025Review = [null, null, null, null, null, null, 21, 26, 25, 26, 3, 24];
-        const data2025Total  = [7, 3, 27, 18, 13, 15, 24, 29, 39, 37, 5, 37];
-
-        // 2026 – January only; total OoS only (no real New/Review breakdown)
-        const data2026Total  = [39, null, null, null, null, null, null, null, null, null, null, null];
-
-        // Annual totals for "All Time" chart – all shown as total-only
-        const annualAT = {
-            labels:  ['2024',         '2025',       '2026'],
-            new:     [null,            null,          null],
-            review:  [null,            null,          null],
-            total:   [72,              254,           39],
-            subtext: ['Jul–Nov only',  'Full year',   'January YTD']
-        };
+        // Data — populated by fetchAndRender()
+        let data2024Total  = Array(12).fill(null);
+        let data2025New    = Array(12).fill(null);
+        let data2025Review = Array(12).fill(null);
+        let data2025Total  = Array(12).fill(null);
+        let data2026Total  = Array(12).fill(null);
+        let annualAT = { labels: ['2024','2025','2026'], new: [null,null,null], review: [null,null,null], total: [0,0,0], subtext: ['','',''] };
 
         let chart;
         let currentPeriod = 'all';
@@ -680,7 +692,8 @@
                 const total = data2024Total.filter(v => v !== null).reduce((s, v) => s + v, 0);
                 noBreakdown('2024 Total', total, 'Jul–Nov only');
             } else if (period === '2026') {
-                noBreakdown('2026 Total', 39, 'January only');
+                const t = data2026Total.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                noBreakdown('2026 Total', t, monthRangeLabel(data2026Total));
             } else if (period === 'all') {
                 const total = annualAT.total.reduce((s, v) => s + v, 0);
                 noBreakdown('All Time Total', total, '2024 + 2025 + 2026 YTD');
@@ -717,13 +730,122 @@
             updateSummary(period);
         }
 
+        // ─── CSV fetch + parse ───────────────────────────────────────────────
+        function parseCSV(text) {
+            const lines = text.trim().split('\n');
+            const headers = lines[0].split(',').map(h => h.trim().replace(/^"|"$/g, ''));
+            const rows = [];
+            for (let i = 1; i < lines.length; i++) {
+                if (!lines[i].trim()) continue;
+                const cols = lines[i].split(',');
+                const row = {};
+                headers.forEach((h, idx) => { row[h] = (cols[idx] || '').trim().replace(/^"|"$/g, ''); });
+                rows.push(row);
+            }
+            return rows;
+        }
+
+        function buildYearData(rows) {
+            const byYear = {};
+            for (const row of rows) {
+                const year = parseInt(row['Year']);
+                const mIdx = MONTH_IDX[row['Month']];
+                if (isNaN(year) || mIdx === undefined) continue;
+                if (!byYear[year]) {
+                    byYear[year] = { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                }
+                const nv = row['New']    !== '' ? parseInt(row['New'])    : null;
+                const rv = row['Review'] !== '' ? parseInt(row['Review']) : null;
+                const tv = row['Total']  !== '' ? parseInt(row['Total'])  : null;
+                byYear[year].new[mIdx]    = (nv !== null && !isNaN(nv)) ? nv : null;
+                byYear[year].review[mIdx] = (rv !== null && !isNaN(rv)) ? rv : null;
+                byYear[year].total[mIdx]  = (tv !== null && !isNaN(tv)) ? tv : null;
+            }
+            return byYear;
+        }
+
+        function monthRangeLabel(arr) {
+            const idx = arr.map((v, i) => v !== null ? i : -1).filter(i => i >= 0);
+            if (!idx.length) return 'No data';
+            if (idx[0] === 0 && idx[idx.length - 1] === 11) return 'Full year';
+            if (idx.length === 1) return months[idx[0]] + ' only';
+            return months[idx[0]] + '\u2013' + months[idx[idx.length - 1]];
+        }
+
+        function showLoading() {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status';
+            el.innerHTML = '<span class="spinner"></span>Loading data\u2026';
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function showDataMessage(msg, isError) {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status' + (isError ? ' error' : '');
+            el.textContent = msg;
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function hideDataMessage() {
+            document.getElementById('dataStatus').style.display = 'none';
+            document.getElementById('oosChart').style.display = '';
+        }
+
+        async function fetchAndRender() {
+            if (!SHEET_CSV_URL) {
+                showDataMessage('No data source configured \u2014 add SHEET_CSV_URL to activate');
+                return;
+            }
+            showLoading();
+            try {
+                const response = await fetch(SHEET_CSV_URL);
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const text = await response.text();
+                const rows = parseCSV(text);
+                const byYear = buildYearData(rows);
+
+                const sumNN   = arr => arr.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                const getYear = y => byYear[y] || { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                const fillTot = (n, r, t) => t.map((v, i) => v !== null ? v : (n[i] !== null && r[i] !== null ? n[i] + r[i] : null));
+
+                const y24 = getYear(2024);
+                const y25 = getYear(2025);
+                const y26 = getYear(2026);
+
+                data2024Total  = y24.total;
+                data2025New    = y25.new;
+                data2025Review = y25.review;
+                data2025Total  = fillTot(y25.new, y25.review, y25.total);
+                data2026Total  = y26.total;
+
+                allData = {
+                    2024: { new: null,        review: null,           total: data2024Total },
+                    2025: { new: data2025New, review: data2025Review, total: data2025Total },
+                    2026: { new: null,        review: null,           total: data2026Total }
+                };
+
+                // Art Therapy annual chart is always total-only (new/review = null)
+                annualAT = {
+                    labels:  ['2024', '2025', '2026'],
+                    new:     [null, null, null],
+                    review:  [null, null, null],
+                    total:   [sumNN(data2024Total), sumNN(data2025Total), sumNN(data2026Total)],
+                    subtext: [monthRangeLabel(data2024Total), monthRangeLabel(data2025Total), monthRangeLabel(data2026Total)]
+                };
+
+                hideDataMessage();
+                createChart(currentPeriod);
+                updateSummary(currentPeriod);
+            } catch (err) {
+                showDataMessage('Unable to load data \u2014 check your connection or sheet permissions', true);
+                console.error('fetchAndRender error:', err);
+            }
+        }
+
         // ─── Date Range Modal ────────────────────────────────────────────────
-        // 2024 and 2026 have total only; 2025 has new/review for Jul–Dec only
-        const allData = {
-            2024: { new: null,         review: null,          total: data2024Total },
-            2025: { new: data2025New,  review: data2025Review, total: data2025Total },
-            2026: { new: null,         review: null,          total: data2026Total }
-        };
+        let allData = {}; // populated by fetchAndRender()
 
         let modalChartInstance = null;
 
@@ -922,9 +1044,8 @@
             });
         }
 
-        // Initialise with All Time view
-        createChart('all');
-        updateSummary('all');
+        // Initialise — load data from Google Sheet
+        fetchAndRender();
 
         function exportToPNG() {
             const controls   = document.getElementById('controls');

--- a/music_therapy_oos_graph.html
+++ b/music_therapy_oos_graph.html
@@ -230,6 +230,25 @@
             padding-top: 12px;
             border-top: 1px solid #eee;
         }
+        .data-status {
+            text-align: center;
+            padding: 60px 20px;
+            color: #7f8c8d;
+            font-size: 14px;
+        }
+        .data-status.error { color: #e74c3c; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .spinner {
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            border: 2px solid rgba(155,107,158,0.2);
+            border-top-color: #9B6B9E;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            vertical-align: middle;
+            margin-right: 8px;
+        }
     </style>
 </head>
 <body>
@@ -247,9 +266,11 @@
             <div style="text-align: center; margin-top: 15px;">
                 <button class="export-btn" onclick="exportToPNG()">📊 Export as PNG</button>
                 <button class="filter-btn" onclick="openDateRangeModal()">📅 Date Range</button>
+                <button class="filter-btn" onclick="fetchAndRender()">&#8635; Refresh</button>
             </div>
         </div>
 
+        <div id="dataStatus" class="data-status" style="display:none;"></div>
         <div class="chart-container">
             <canvas id="oosChart"></canvas>
         </div>
@@ -368,31 +389,20 @@
     </div>
 
     <script>
-        // Data - months
+        const SHEET_CSV_URL = ""; // paste published CSV URL here
+
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const MONTH_IDX = {Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};
 
-        // 2024 data (Jul–Dec only – total OoS, no New/Review breakdown)
-        const data2024Total = [null, null, null, null, null, null, 28, 82, 60, 83, 43, 16];
-
-        // 2025 NEW vs REVIEW – Jan–Jun estimated; Jul–Dec actual
-        const data2025New = [6, 1, 1, 8, 22, 51, 28, 27, 50, 42, 33, 29];
-        const data2025Review = [5, 0, 1, 14, 41, 95, 102, 124, 95, 105, 71, 62];
-        const data2025Total = data2025New.map((val, i) => val + data2025Review[i]);
-
-        // 2026 data (Jan only)
-        const data2026New = [57, null, null, null, null, null, null, null, null, null, null, null];
-        const data2026Review = [109, null, null, null, null, null, null, null, null, null, null, null];
-        const data2026Total = [166, null, null, null, null, null, null, null, null, null, null, null];
-
-        // Annual totals for "All Time" stacked bar chart
-        // 2024: null new/review (total only) | 2025: full year | 2026: Jan YTD
-        const annualMT = {
-            labels:  ['2024',         '2025',       '2026'],
-            new:     [null,            298,          57],
-            review:  [null,            715,          109],
-            total:   [312,             1013,         166],
-            subtext: ['Jul–Dec only',  'Full year',  'January YTD']
-        };
+        // Data — populated by fetchAndRender()
+        let data2024Total  = Array(12).fill(null);
+        let data2025New    = Array(12).fill(null);
+        let data2025Review = Array(12).fill(null);
+        let data2025Total  = Array(12).fill(null);
+        let data2026New    = Array(12).fill(null);
+        let data2026Review = Array(12).fill(null);
+        let data2026Total  = Array(12).fill(null);
+        let annualMT = { labels: ['2024','2025','2026'], new: [null,null,null], review: [null,null,null], total: [0,0,0], subtext: ['','',''] };
 
         let chart;
         let currentPeriod = 'all';
@@ -670,18 +680,20 @@
                 label = '2025 Total';
                 subtext = 'Full year';
             } else if (period === '2026') {
-                totalNew = 57;
-                totalReview = 109;
-                total = 166;
-                label = '2026 Total';
-                subtext = 'January only';
+                totalNew    = data2026New.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                totalReview = data2026Review.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                total       = data2026Total.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                label   = '2026 Total';
+                subtext = monthRangeLabel(data2026Total);
             } else { // all
-                const new2025 = data2025New.reduce((sum, val) => sum + val, 0);
-                const review2025 = data2025Review.reduce((sum, val) => sum + val, 0);
-                const total2024 = data2024Total.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
-                totalNew = new2025 + 57;
-                totalReview = review2025 + 109;
-                total = totalNew + totalReview + total2024;
+                const new2025    = data2025New.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                const review2025 = data2025Review.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                const total2024  = data2024Total.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                const new2026    = data2026New.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                const review2026 = data2026Review.filter(v => v !== null).reduce((sum, val) => sum + val, 0);
+                totalNew    = new2025 + new2026;
+                totalReview = review2025 + review2026;
+                total       = totalNew + totalReview + total2024;
                 label = 'All Time Total';
                 subtext = '2024–2026 YTD';
             }
@@ -712,13 +724,124 @@
             updateSummary(period);
         }
 
+        // ─── CSV fetch + parse ───────────────────────────────────────────────
+        function parseCSV(text) {
+            const lines = text.trim().split('\n');
+            const headers = lines[0].split(',').map(h => h.trim().replace(/^"|"$/g, ''));
+            const rows = [];
+            for (let i = 1; i < lines.length; i++) {
+                if (!lines[i].trim()) continue;
+                const cols = lines[i].split(',');
+                const row = {};
+                headers.forEach((h, idx) => { row[h] = (cols[idx] || '').trim().replace(/^"|"$/g, ''); });
+                rows.push(row);
+            }
+            return rows;
+        }
+
+        function buildYearData(rows) {
+            const byYear = {};
+            for (const row of rows) {
+                const year = parseInt(row['Year']);
+                const mIdx = MONTH_IDX[row['Month']];
+                if (isNaN(year) || mIdx === undefined) continue;
+                if (!byYear[year]) {
+                    byYear[year] = { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                }
+                const nv = row['New']    !== '' ? parseInt(row['New'])    : null;
+                const rv = row['Review'] !== '' ? parseInt(row['Review']) : null;
+                const tv = row['Total']  !== '' ? parseInt(row['Total'])  : null;
+                byYear[year].new[mIdx]    = (nv !== null && !isNaN(nv)) ? nv : null;
+                byYear[year].review[mIdx] = (rv !== null && !isNaN(rv)) ? rv : null;
+                byYear[year].total[mIdx]  = (tv !== null && !isNaN(tv)) ? tv : null;
+            }
+            return byYear;
+        }
+
+        function monthRangeLabel(arr) {
+            const idx = arr.map((v, i) => v !== null ? i : -1).filter(i => i >= 0);
+            if (!idx.length) return 'No data';
+            if (idx[0] === 0 && idx[idx.length - 1] === 11) return 'Full year';
+            if (idx.length === 1) return months[idx[0]] + ' only';
+            return months[idx[0]] + '\u2013' + months[idx[idx.length - 1]];
+        }
+
+        function showLoading() {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status';
+            el.innerHTML = '<span class="spinner"></span>Loading data\u2026';
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function showDataMessage(msg, isError) {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status' + (isError ? ' error' : '');
+            el.textContent = msg;
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function hideDataMessage() {
+            document.getElementById('dataStatus').style.display = 'none';
+            document.getElementById('oosChart').style.display = '';
+        }
+
+        async function fetchAndRender() {
+            if (!SHEET_CSV_URL) {
+                showDataMessage('No data source configured \u2014 add SHEET_CSV_URL to activate');
+                return;
+            }
+            showLoading();
+            try {
+                const response = await fetch(SHEET_CSV_URL);
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const text = await response.text();
+                const rows = parseCSV(text);
+                const byYear = buildYearData(rows);
+
+                const sumNN   = arr => arr.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                const getYear = y => byYear[y] || { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                const fillTot = (n, r, t) => t.map((v, i) => v !== null ? v : (n[i] !== null && r[i] !== null ? n[i] + r[i] : null));
+                const hasAny  = arr => arr.some(v => v !== null);
+
+                const y24 = getYear(2024);
+                const y25 = getYear(2025);
+                const y26 = getYear(2026);
+
+                data2024Total  = y24.total;
+                data2025New    = y25.new;
+                data2025Review = y25.review;
+                data2025Total  = fillTot(y25.new, y25.review, y25.total);
+                data2026New    = y26.new;
+                data2026Review = y26.review;
+                data2026Total  = fillTot(y26.new, y26.review, y26.total);
+
+                allData = {
+                    2024: { new: null,        review: null,           total: data2024Total },
+                    2025: { new: data2025New, review: data2025Review, total: data2025Total },
+                    2026: { new: data2026New, review: data2026Review, total: data2026Total }
+                };
+
+                annualMT = {
+                    labels:  ['2024', '2025', '2026'],
+                    new:     [null, hasAny(data2025New) ? sumNN(data2025New) : null, hasAny(data2026New) ? sumNN(data2026New) : null],
+                    review:  [null, hasAny(data2025Review) ? sumNN(data2025Review) : null, hasAny(data2026Review) ? sumNN(data2026Review) : null],
+                    total:   [sumNN(data2024Total), sumNN(data2025Total), sumNN(data2026Total)],
+                    subtext: [monthRangeLabel(data2024Total), monthRangeLabel(data2025Total), monthRangeLabel(data2026Total)]
+                };
+
+                hideDataMessage();
+                createChart(currentPeriod);
+                updateSummary(currentPeriod);
+            } catch (err) {
+                showDataMessage('Unable to load data \u2014 check your connection or sheet permissions', true);
+                console.error('fetchAndRender error:', err);
+            }
+        }
+
         // ─── Date Range Modal ────────────────────────────────────────────────
-        // Unified data lookup: years where new/review split is unavailable use null
-        const allData = {
-            2024: { new: null,         review: null,          total: data2024Total },
-            2025: { new: data2025New,  review: data2025Review, total: data2025Total },
-            2026: { new: data2026New,  review: data2026Review, total: data2026Total }
-        };
+        let allData = {}; // populated by fetchAndRender()
 
         let modalChartInstance = null;
 
@@ -917,9 +1040,8 @@
             });
         }
 
-        // Initialize with 'all' view
-        createChart('all');
-        updateSummary('all');
+        // Initialise — load data from Google Sheet
+        fetchAndRender();
 
         // Export to PNG function
         function exportToPNG() {

--- a/spiritual_care_oos_graph.html
+++ b/spiritual_care_oos_graph.html
@@ -236,6 +236,25 @@
             padding-top: 12px;
             border-top: 1px solid #eee;
         }
+        .data-status {
+            text-align: center;
+            padding: 60px 20px;
+            color: #7f8c8d;
+            font-size: 14px;
+        }
+        .data-status.error { color: #e74c3c; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .spinner {
+            display: inline-block;
+            width: 18px;
+            height: 18px;
+            border: 2px solid rgba(74,155,199,0.2);
+            border-top-color: #4A9BC7;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            vertical-align: middle;
+            margin-right: 8px;
+        }
     </style>
 </head>
 <body>
@@ -253,9 +272,11 @@
             <div style="text-align: center; margin-top: 15px;">
                 <button class="export-btn" onclick="exportToPNG()">&#128202; Export as PNG</button>
                 <button class="filter-btn" onclick="openDateRangeModal()">&#128197; Date Range</button>
+                <button class="filter-btn" onclick="fetchAndRender()">&#8635; Refresh</button>
             </div>
         </div>
 
+        <div id="dataStatus" class="data-status" style="display:none;"></div>
         <div class="chart-container">
             <canvas id="oosChart"></canvas>
         </div>
@@ -358,31 +379,22 @@
     </div>
 
     <script>
+        const SHEET_CSV_URL = ""; // paste published CSV URL here
+
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const MONTH_IDX = {Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};
 
-        // 2024 – provided totals, split 35% New / 65% Review
-        const data2024New    = [179, 246, 177, 179, 230, 207, 287, 282, 253, 254, 259, 265];
-        const data2024Review = [331, 457, 328, 332, 427, 384, 534, 523, 469, 471, 482, 492];
-        const data2024Total  = data2024New.map((v, i) => v + data2024Review[i]);
-
-        // 2025 – provided totals, split 35% New / 65% Review
-        const data2025New    = [180, 219, 269, 253, 305, 281, 274, 255, 255, 303, 241, 243];
-        const data2025Review = [335, 406, 499, 469, 567, 522, 508, 473, 473, 563, 447, 452];
-        const data2025Total  = data2025New.map((v, i) => v + data2025Review[i]);
-
-        // 2026 – January only
-        const data2026New    = [233, null, null, null, null, null, null, null, null, null, null, null];
-        const data2026Review = [434, null, null, null, null, null, null, null, null, null, null, null];
-        const data2026Total  = [667, null, null, null, null, null, null, null, null, null, null, null];
-
-        // Annual totals for "All Time" stacked bar chart
-        const annualSC = {
-            labels:  ['2024',  '2025',  '2026'],
-            new:     [2818,    3078,    233],
-            review:  [5230,    5714,    434],
-            total:   [8048,    8792,    667],
-            subtext: ['Full year', 'Full year', 'January YTD']
-        };
+        // Data — populated by fetchAndRender()
+        let data2024New    = Array(12).fill(null);
+        let data2024Review = Array(12).fill(null);
+        let data2024Total  = Array(12).fill(null);
+        let data2025New    = Array(12).fill(null);
+        let data2025Review = Array(12).fill(null);
+        let data2025Total  = Array(12).fill(null);
+        let data2026New    = Array(12).fill(null);
+        let data2026Review = Array(12).fill(null);
+        let data2026Total  = Array(12).fill(null);
+        let annualSC = { labels: ['2024','2025','2026'], new: [0,0,0], review: [0,0,0], total: [0,0,0], subtext: ['','',''] };
 
         let chart;
         let currentPeriod = 'all';
@@ -591,14 +603,14 @@
                 label       = '2025 Total';
                 subtext     = 'Full year';
             } else if (period === '2026') {
-                totalNew    = 233;
-                totalReview = 434;
-                total       = 667;
+                totalNew    = data2026New.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                totalReview = data2026Review.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                total       = data2026Total.filter(v => v !== null).reduce((s, v) => s + v, 0);
                 label       = '2026 Total';
-                subtext     = 'January only';
+                subtext     = monthRangeLabel(data2026Total);
             } else { // all
-                totalNew    = annualSC.new.reduce((s, v) => s + v, 0);
-                totalReview = annualSC.review.reduce((s, v) => s + v, 0);
+                totalNew    = annualSC.new.reduce((s, v) => s + (v || 0), 0);
+                totalReview = annualSC.review.reduce((s, v) => s + (v || 0), 0);
                 total       = totalNew + totalReview;
                 label       = 'All Time Total';
                 subtext     = '2024 + 2025 + 2026 YTD';
@@ -629,13 +641,126 @@
             updateSummary(period);
         }
 
+        // ─── CSV fetch + parse ───────────────────────────────────────────────
+        function parseCSV(text) {
+            const lines = text.trim().split('\n');
+            const headers = lines[0].split(',').map(h => h.trim().replace(/^"|"$/g, ''));
+            const rows = [];
+            for (let i = 1; i < lines.length; i++) {
+                if (!lines[i].trim()) continue;
+                const cols = lines[i].split(',');
+                const row = {};
+                headers.forEach((h, idx) => { row[h] = (cols[idx] || '').trim().replace(/^"|"$/g, ''); });
+                rows.push(row);
+            }
+            return rows;
+        }
+
+        function buildYearData(rows) {
+            const byYear = {};
+            for (const row of rows) {
+                const year = parseInt(row['Year']);
+                const mIdx = MONTH_IDX[row['Month']];
+                if (isNaN(year) || mIdx === undefined) continue;
+                if (!byYear[year]) {
+                    byYear[year] = { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                }
+                const nv = row['New']    !== '' ? parseInt(row['New'])    : null;
+                const rv = row['Review'] !== '' ? parseInt(row['Review']) : null;
+                const tv = row['Total']  !== '' ? parseInt(row['Total'])  : null;
+                byYear[year].new[mIdx]    = (nv !== null && !isNaN(nv)) ? nv : null;
+                byYear[year].review[mIdx] = (rv !== null && !isNaN(rv)) ? rv : null;
+                byYear[year].total[mIdx]  = (tv !== null && !isNaN(tv)) ? tv : null;
+            }
+            return byYear;
+        }
+
+        function monthRangeLabel(arr) {
+            const idx = arr.map((v, i) => v !== null ? i : -1).filter(i => i >= 0);
+            if (!idx.length) return 'No data';
+            if (idx[0] === 0 && idx[idx.length - 1] === 11) return 'Full year';
+            if (idx.length === 1) return months[idx[0]] + ' only';
+            return months[idx[0]] + '\u2013' + months[idx[idx.length - 1]];
+        }
+
+        function showLoading() {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status';
+            el.innerHTML = '<span class="spinner"></span>Loading data\u2026';
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function showDataMessage(msg, isError) {
+            const el = document.getElementById('dataStatus');
+            el.className = 'data-status' + (isError ? ' error' : '');
+            el.textContent = msg;
+            el.style.display = 'block';
+            document.getElementById('oosChart').style.display = 'none';
+        }
+
+        function hideDataMessage() {
+            document.getElementById('dataStatus').style.display = 'none';
+            document.getElementById('oosChart').style.display = '';
+        }
+
+        async function fetchAndRender() {
+            if (!SHEET_CSV_URL) {
+                showDataMessage('No data source configured \u2014 add SHEET_CSV_URL to activate');
+                return;
+            }
+            showLoading();
+            try {
+                const response = await fetch(SHEET_CSV_URL);
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const text = await response.text();
+                const rows = parseCSV(text);
+                const byYear = buildYearData(rows);
+
+                const sumNN   = arr => arr.filter(v => v !== null).reduce((s, v) => s + v, 0);
+                const getYear = y => byYear[y] || { new: Array(12).fill(null), review: Array(12).fill(null), total: Array(12).fill(null) };
+                const fillTot = (n, r, t) => t.map((v, i) => v !== null ? v : (n[i] !== null && r[i] !== null ? n[i] + r[i] : null));
+                const hasAny  = arr => arr.some(v => v !== null);
+
+                const y24 = getYear(2024);
+                const y25 = getYear(2025);
+                const y26 = getYear(2026);
+
+                data2024New    = y24.new;
+                data2024Review = y24.review;
+                data2024Total  = fillTot(y24.new, y24.review, y24.total);
+                data2025New    = y25.new;
+                data2025Review = y25.review;
+                data2025Total  = fillTot(y25.new, y25.review, y25.total);
+                data2026New    = y26.new;
+                data2026Review = y26.review;
+                data2026Total  = fillTot(y26.new, y26.review, y26.total);
+
+                allData = {
+                    2024: { new: data2024New, review: data2024Review, total: data2024Total },
+                    2025: { new: data2025New, review: data2025Review, total: data2025Total },
+                    2026: { new: data2026New, review: data2026Review, total: data2026Total }
+                };
+
+                annualSC = {
+                    labels:  ['2024', '2025', '2026'],
+                    new:     [hasAny(data2024New) ? sumNN(data2024New) : 0, hasAny(data2025New) ? sumNN(data2025New) : 0, hasAny(data2026New) ? sumNN(data2026New) : 0],
+                    review:  [hasAny(data2024Review) ? sumNN(data2024Review) : 0, hasAny(data2025Review) ? sumNN(data2025Review) : 0, hasAny(data2026Review) ? sumNN(data2026Review) : 0],
+                    total:   [sumNN(data2024Total), sumNN(data2025Total), sumNN(data2026Total)],
+                    subtext: [monthRangeLabel(data2024Total), monthRangeLabel(data2025Total), monthRangeLabel(data2026Total)]
+                };
+
+                hideDataMessage();
+                createChart(currentPeriod);
+                updateSummary(currentPeriod);
+            } catch (err) {
+                showDataMessage('Unable to load data \u2014 check your connection or sheet permissions', true);
+                console.error('fetchAndRender error:', err);
+            }
+        }
+
         // ─── Date Range Modal ────────────────────────────────────────────────
-        // All years for Spiritual Care have full New + Review breakdown
-        const allData = {
-            2024: { new: data2024New, review: data2024Review, total: data2024Total },
-            2025: { new: data2025New, review: data2025Review, total: data2025Total },
-            2026: { new: data2026New, review: data2026Review, total: data2026Total }
-        };
+        let allData = {}; // populated by fetchAndRender()
 
         let modalChartInstance = null;
 
@@ -817,9 +942,8 @@
             });
         }
 
-        // Initialise with All Time view
-        createChart('all');
-        updateSummary('all');
+        // Initialise — load data from Google Sheet
+        fetchAndRender();
 
         function exportToPNG() {
             const controls   = document.getElementById('controls');


### PR DESCRIPTION
- Add SHEET_CSV_URL constant to each graph file (empty placeholder for Jarran to fill)
- Replace all hardcoded data arrays with fetchAndRender() that fetches CSV, parses Year/Month/New/Review/Total columns, and feeds existing chart logic
- All chart types, colours, and layout preserved exactly — data pipeline only
- Shows loading spinner while fetching; clear error messages on failure or missing URL; Refresh button added consistent with existing UI style
- Fix hardcoded 2026 summary values to reference live data arrays
- Add NANCY_GUIDE.md: plain-English update instructions for Nancy
- Add GOOGLE_SHEETS_SETUP.md: full sheet structure and publish-to-CSV steps

https://claude.ai/code/session_01SBEur5omFNZKreQEhYWCDQ